### PR TITLE
fix version solving failed error due to coast_audio_fft dependent coast_audio in path dependencies

### DIFF
--- a/examples/audio_recorder/pubspec.lock
+++ b/examples/audio_recorder/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   audio_service:
     dependency: "direct main"
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -164,10 +164,11 @@ packages:
   coast_audio:
     dependency: transitive
     description:
-      path: "../../packages/coast_audio"
-      relative: true
-    source: path
-    version: "0.0.1"
+      name: coast_audio
+      sha256: "09dbf5a75e1c8a6f549c5694a5ce04eb7e9422e2c2244448bb671a2738fd3424"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2+1"
   coast_audio_fft:
     dependency: "direct main"
     description:
@@ -178,10 +179,11 @@ packages:
   coast_audio_miniaudio:
     dependency: transitive
     description:
-      path: "../../packages/coast_audio_miniaudio"
-      relative: true
-    source: path
-    version: "0.0.1"
+      name: coast_audio_miniaudio
+      sha256: "57ea43c8c726571c87f912d078d3ca1a6a2866c74ec394460f9a4183a5f7588b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1+1"
   code_builder:
     dependency: transitive
     description:
@@ -194,10 +196,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
@@ -416,10 +418,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -456,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -472,10 +474,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -504,10 +506,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider:
     dependency: "direct main"
     description:
@@ -773,10 +775,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   timing:
     dependency: transitive
     description:
@@ -850,5 +852,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.3 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.3.0"

--- a/packages/coast_audio_fft/pubspec.yaml
+++ b/packages/coast_audio_fft/pubspec.yaml
@@ -8,8 +8,7 @@ environment:
 
 dependencies:
   fftea: ^1.2.0+1
-  coast_audio:
-    path: ../coast_audio
+  coast_audio: ^0.0.2
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
Change `coast_audio ` to dependent on the `pub.dev` version, fix https://github.com/SKKbySSK/coast_audio/issues/6

Since I upgrade the Flutter SDK to 3.10, which cause the `pubspec.lock` updated, I recommend not check-in all the `pubspec.lock` file, so that it can avoid the `pubspec.lock` files be updated due to different Flutter SDK version.