### PR TITLE
add namespace to build.gradle for AGP 8.0

### DIFF
--- a/packages/flutter_coast_audio_miniaudio/android/build.gradle
+++ b/packages/flutter_coast_audio_miniaudio/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.example.flutter_coast_audio_miniaudio'
+    }
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
android gradle plugin now requires a `namespace` attribute in `build.gradle`. This PR makes it compatible with the latest AGP.